### PR TITLE
Treat TimeoutError during entry setup as ConfigEntryNotReady

### DIFF
--- a/custom_components/pysmaplus/__init__.py
+++ b/custom_components/pysmaplus/__init__.py
@@ -99,9 +99,9 @@ async def getPysmaInstance(hass: HomeAssistant, data: dict[str, Any]) -> Device:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up sma from a config entry."""
-    # Init the SMA interface
-    sma = await getPysmaInstance(hass, entry.data)
     try:
+        # Init the SMA interface (getPysmaInstance already opens a session)
+        sma = await getPysmaInstance(hass, entry.data)
         # Start seession/Test connection
         await sma.new_session()
         # Get updated device info
@@ -112,6 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except (
         pysma.exceptions.SmaReadException,
         pysma.exceptions.SmaConnectionException,
+        TimeoutError,
     ) as exc:
         raise ConfigEntryNotReady from exc
 


### PR DESCRIPTION
Fixes #127.

A `TimeoutError` raised during entry setup (e.g. `speedwireem` when no multicast datagram arrives right after a Home Assistant restart) escaped `async_setup_entry`, leaving the entry in `setup_error` without any retry and all entities `unavailable` until a manual reload.

This adds `TimeoutError` to the setup `except` tuple, mirroring the update coordinator's existing handling, and moves the `getPysmaInstance()` call into the guarded block, since it already opens a session itself and can raise the same timeout before the handler.

Tested on my production instance (Home Assistant 2026.6.2, SHM2 via `speedwireem`) since 2026-07-11.
